### PR TITLE
Separate sonar scan as new workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,11 +15,5 @@ jobs:
         java-version: '11'
         distribution: 'zulu'
 
-    - name: Build and Analyze Code Coverage
-      run: mvn clean install -Pcoverage
-      
-    - name: Sonar Scan
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: mvn sonar:sonar -Dsonar.projectKey=cloudfoundry_multiapps
+    - name: Build and Run Unit Tests
+      run: mvn clean install

--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -11,20 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'zulu'
-        
-    - name: Cache SonarCloud packages
-      uses: actions/cache@v3
-      with:
-        path: ~/.sonar/cache
-        key: ${{ runner.os }}-sonar
-        restore-keys: ${{ runner.os }}-sonar
-        
+
     - name: Cache Maven packages
       uses: actions/cache@v3
       with:
@@ -32,11 +24,5 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
-    - name: Build and Analyze Code Coverage
-      run: mvn clean install -Pcoverage
-      
-    - name: Sonar Scan
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: mvn sonar:sonar -Dsonar.projectKey=cloudfoundry_multiapps
+    - name: Build and Run Unit Tests
+      run: mvn clean install

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -1,0 +1,28 @@
+name: Multiapps Sonar Scan
+
+on:
+  push:
+   branches: [ "master" ]
+  pull_request:
+   branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'zulu'
+
+    - name: Build and Analyze Code Coverage
+      run: mvn clean install -Pcoverage
+      
+    - name: Sonar Scan
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      run: mvn sonar:sonar -Dsonar.projectKey=cloudfoundry_multiapps
+


### PR DESCRIPTION
This change is necessary in order to have at least green build job when PR is opened through fork repo. The project is still using java 11 but sonarcloud.io requires scans using minimum java 17, so sonar scans will be executed using java 17 instead 11

