### PR TITLE
fixed circular ref false positive during property resolution with mul…

### DIFF
--- a/multiapps-common-test/src/main/java/org/cloudfoundry/multiapps/common/test/Tester.java
+++ b/multiapps-common-test/src/main/java/org/cloudfoundry/multiapps/common/test/Tester.java
@@ -98,8 +98,8 @@ public class Tester {
         }
         String exceptionMessage = e.getMessage();
         assertTrue(exceptionMessage.contains(expectation.getExpectationAsString()),
-                   MessageFormat.format("Exception's message doesn't match up! Expected [{0}] to contain [{1}]!",
-                                        expectation.getExpectationAsString(), exceptionMessage));
+                   MessageFormat.format("Exception's message doesn't match up! Expected [{0}] to contain [{1}]!", exceptionMessage,
+                                        expectation.getExpectationAsString()));
     }
 
     private Object loadResourceAsJsonObject(String resource) {

--- a/multiapps-mta/src/test/resources/org/cloudfoundry/multiapps/mta/resolvers/moduleProperties.yaml
+++ b/multiapps-mta/src/test/resources/org/cloudfoundry/multiapps/mta/resolvers/moduleProperties.yaml
@@ -23,3 +23,19 @@ tricky-map:
   : "5": stop
   ? "3/4/5"
   : this is actually unreachable
+foo: ${qux}-${baz}-${bar}-${baz}-${qux}
+bar: ${baz}-${qux}
+baz: ${qux}
+qux: "qux"
+NO_CIRCULAR_REF: ${foo}-${bar}-${baz}
+NO_CIRCULAR_REF_IN_MAP:
+  a: ${NO_CIRCULAR_REF_IN_MAP/b}-${NO_CIRCULAR_REF_IN_MAP/c}
+  b: ${NO_CIRCULAR_REF_IN_MAP/c}
+  c: "ha"
+head: ${baz}-${body}
+body: ${baz}-${tail}
+tail: ${baz}-${head}
+CIRCULAR_REF: ${foo}-${head}
+CIRCULAR_REF_MAP_IN_MAP:
+  key:
+    key: ${head}


### PR DESCRIPTION
…tiple references

LMCROSSITXSADEPLOY-2936

Using multiple references linking to same variable was incorrectly detected as a circular reference - Fixed ref key context to reset on each subsequent ref.
Fixed error message in Tester class